### PR TITLE
Buttons WORK

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,25 +1,15 @@
-.btn-square {
-  width: 44px;
-  height: 44px;
-  color: $off-white;
-  background-color: $blue;
-  border-radius: 4px;
-  border:none;
-  font-size: 20px;
-  text-decoration: none;
-  text-align: center;
-}
 
 .btn-text {
   color: $off-white;
   background-color: $blue;
   border-radius: 4px;
-  border:none;
+  border: none;
   font-size: 20px;
   font-weight: 400;
   text-decoration: none;
   text-align: center;
-  padding:8px;
+  padding: 8px;
+
   &:hover {
     background-color: $light-blue;
     color: $off-white;
@@ -28,25 +18,57 @@
 
 .btn-text-white {
   color: $blue;
-  background-color:$off-white;
+  background-color: $off-white;
   border-radius: 4px;
-  border:none;
+  border: none;
   font-size: 20px;
   font-weight: 400;
   text-decoration: none;
   text-align: center;
-  padding:8px;
+  padding: 8px;
 }
 
-.btn-square-white{
+.button-custom {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+
+  i {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.btn-rounded-circle-back-show {
+  background-color: $off-white;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+}
+
+.btn-square {
   width: 44px;
   height: 44px;
-  color: $blue;
-  background-color: $off-white;
   border-radius: 4px;
-  border:none;
+  border: none;
   font-size: 20px;
   text-decoration: none;
   text-align: center;
+}
+
+.btn-white {
+  color: $blue;
+  background-color: $off-white;
   margin-bottom: 16px;
+}
+
+.btn-blue {
+  color: $off-white;
+  background-color: $blue;
+}
+
+.navigation-container {
+  padding: 10px 15px;
 }

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -69,6 +69,11 @@
   background-color: $blue;
 }
 
+.navigation-container-relative {
+  position: relative;
+}
+
 .navigation-container {
   padding: 10px 15px;
+  z-index: 100;
 }

--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -28,6 +28,17 @@
   width: 100px;
 }
 
+.custom-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  * {
+    margin: 0;
+    padding: 0;
+  }
+}
+
 // Custom form area
 
 .custom--form--field {
@@ -36,6 +47,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+
   .caret {
     margin: 0;
     padding-right: 0;
@@ -47,6 +59,7 @@
   border-top: none;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
+
   :not(:first-child) {
     border-top: 0.5px solid $gray;
   }

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -3,3 +3,7 @@
 // Define fonts for body and headers
 $body-font: 'Quicksand', "sans-serif";
 $headers-font: 'Quicksand', "sans-serif";
+
+a {
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/pages/_flats_show.scss
+++ b/app/assets/stylesheets/pages/_flats_show.scss
@@ -1,21 +1,3 @@
-.back-arrow1 {
-  font-size: 20px;
-  margin-top: -10px;
-  margin-bottom: 30px;
-  padding-left: 0px;
-  padding-top: 18px;
-}
-
-.btn-rounded-circle-back-show {
-  background-color: $off-white;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: none;
-  margin-top: 0px;
-  margin-left: 0px;
-
-}
 
 .edit-share {
   margin-top: 95px;
@@ -29,65 +11,76 @@
   padding: 10px 30px 10px 7px;
 }
 
-.fileList{
+.fileList {
   position: relative;
   max-width: 500px;
   margin: auto;
 }
-.fileInput{
+
+.fileInput {
   padding: 20px;
-  border: 1px solid rgba(0,0,0,0.1);
+  border: 1px solid rgba(0, 0, 0, 0.1);
   width: 100%;
   border-radius: 15px;
-  box-shadow: 0 2px 2px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.1);
   background: $off-white;
   height: 80px;
   margin-bottom: 10px;
   position: relative;
-  &:first-of-type{
+
+  &:first-of-type {
     z-index: 10;
   }
-  &:nth-of-type(2){
+
+  &:nth-of-type(2) {
     z-index: 9;
   }
-  &:nth-of-type(3){
+
+  &:nth-of-type(3) {
     z-index: 8;
   }
-  &:nth-of-type(4){
+
+  &:nth-of-type(4) {
     z-index: 7;
   }
-  &:nth-of-type(5){
+
+  &:nth-of-type(5) {
     z-index: 6;
   }
-  &:nth-of-type(6){
+
+  &:nth-of-type(6) {
     z-index: 5;
   }
-  &:nth-of-type(7){
+
+  &:nth-of-type(7) {
     z-index: 4;
   }
-  &:nth-of-type(8){
+
+  &:nth-of-type(8) {
     z-index: 3;
   }
 }
 
-.fileList.closed .fileInput{
-  &:first-of-type{
-    box-shadow: 0 3px 4px -2px rgba(0,0,0,0.1), 0 10px 0 -4px #e3e3e3, 0 21px 0 -10px #cdcdcd, 0 21px 5px -8px rgba(0,0,0,0.1);
+.fileList.closed .fileInput {
+  &:first-of-type {
+    box-shadow: 0 3px 4px -2px rgba(0, 0, 0, 0.1), 0 10px 0 -4px #e3e3e3, 0 21px 0 -10px #cdcdcd, 0 21px 5px -8px rgba(0, 0, 0, 0.1);
     transition: box-shadow ease 300ms;
     transition-delay: 250ms;
   }
-  &:not(:first-of-type){
+
+  &:not(:first-of-type) {
     animation: hideItems 1s forwards;
     animation-timing-function: ease;
   }
 }
 
-.fileList.showing .fileInput{
-  &:first-of-type{
-    box-shadow: 0 3px 4px -2px rgba(0,0,0,0.1);
+.fileList.showing .fileInput {
+  &:first-of-type {
+    box-shadow: 0 3px 4px -2px rgba(0, 0, 0, 0.1);
     transition: box-shadow ease 300ms;
   }
-  &:not(:first-of-type){
+
+  &:not(:first-of-type) {
     animation: showItems 700ms forwards;
     animation-timing-function: ease;
   }
@@ -99,57 +92,58 @@
   margin: auto;
 }
 
-@keyframes hideItems{
-  0%{
+@keyframes hideItems {
+  0% {
     margin-top: 0;
   }
-  30%{
+  30% {
     opacity: 1;
   }
-  60%{
+  60% {
     opacity: 0;
     transform: scale(0.98);
   }
-  80%{
+  80% {
     transform: scale(0.5);
   }
-  100%{
+  100% {
     opacity: 0;
     transform: scale(0);
     margin-top: -25%;
   }
 }
-@keyframes showItems{
-  100%{
+
+@keyframes showItems {
+  100% {
     opacity: 1;
     margin-top: 0;
     transform: scale(1);
   }
-  10%{
+  10% {
     opacity: 0;
   }
-  0%{
+  0% {
     opacity: 0;
     transform: scale(0.95);
     margin-top: -25%;
   }
 }
 
-.image-flat-good{
+.image-flat-good {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-top-left-radius:4px ;
-  border-bottom-left-radius: 4px ;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
   opacity: 0.6;
   position: static;
 }
 
-.image-flat-good-icon{
+.image-flat-good-icon {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius:4px ;
+  border-radius: 4px;
   opacity: 0.6;
   position: static;
 }
@@ -157,8 +151,8 @@
 .background-blue {
   background-color: $blue;
   position: relative;
-  border-top-left-radius:4px ;
-  border-bottom-left-radius: 4px ;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
 }
 
 .icon-good {
@@ -171,14 +165,14 @@
 .background-red {
   background-color: $red;
   position: relative;
-  border-top-left-radius:4px ;
-  border-bottom-left-radius: 4px ;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
 }
 
 .background-red-icon {
   background-color: $red;
   position: relative;
-  border-radius:4px ;
+  border-radius: 4px;
   height: 100px;
   width: 100px;
   margin-left: 16px;
@@ -194,14 +188,14 @@
 .background-beige {
   background-color: #B7B7B7;
   position: relative;
-  border-top-left-radius:4px ;
-  border-bottom-left-radius: 4px ;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
 }
 
-.background-beige-icon{
+.background-beige-icon {
   background-color: #B7B7B7;
   position: relative;
-  border-radius:4px ;
+  border-radius: 4px;
   height: 100px;
   width: 100px;
   margin-right: 16px;
@@ -215,10 +209,10 @@
 }
 
 .card-belonging {
-  height:110px;
+  height: 110px;
   box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.12);
   border-radius: 4px;
-  border:none;
+  border: none;
 }
 
 .text-belonging {
@@ -244,13 +238,11 @@
   border: none;
 }
 
-.spacing-header{
-  padding-left: 30px;
-  padding-right: 30px;
+.spacing-header {
   color: $off-white;
-  padding-top: 30px;
-  padding-bottom: 30px;
-  margin-top: -6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .modal-button {
@@ -266,7 +258,7 @@
 .card-tenant {
   box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.12);
   border-radius: 4px;
-  border:none;
+  border: none;
   padding-top: 8px;
   padding-bottom: 8px;
   padding-left: 12px;
@@ -329,11 +321,11 @@ input.form-control {
   color: $blue;
 }
 
-.btn-sticky-pill{
+.btn-sticky-pill {
   color: $off-white;
   background-color: #FA7500;
   border-radius: 150px;
-  border:none;
+  border: none;
   margin-top: 4px;
   margin-bottom: 4px;
   font-size: 22px;
@@ -344,12 +336,12 @@ input.form-control {
   width: 200px;
   height: 50px;
   box-shadow: 2px 2px 4px #979797;
-  text-align:center;
-  display:block;
+  text-align: center;
+  display: block;
   font-weight: 900;
 }
 
-.modal-footer{
+.modal-footer {
   align-items: center !important;
 }
 

--- a/app/views/belongings/show.html.erb
+++ b/app/views/belongings/show.html.erb
@@ -5,16 +5,16 @@
         <% @belonging.photos.each_with_index do |photo, index| %>
           <% if index == 0 %>
             <div class="carousel-item active ">
-              <%= cl_image_tag photo.key, height: 200, width: 425, crop: :fill, class: "image-big d-block " %>
+              <%= cl_image_tag photo.key, height: 200, width: 400, crop: :fill, class: "image-big d-block " %>
             </div>
           <% else %>
             <div class="carousel-item">
-              <%= cl_image_tag photo.key, height: 200, width: 425, crop: :fill, class: "image-big d-block" %>
+              <%= cl_image_tag photo.key, height: 200, width: 400, crop: :fill, class: "image-big d-block" %>
             </div>
           <% end %>
         <% end %>
-        <div class="d-flex">
-          <%= button_to flat_path(@belonging.flat), class: "btn-rounded-circle-back-show button-custom" do %>
+        <div class="navigation-container navigation-container-relative">
+          <%= link_to flat_path(@belonging.flat), class: "btn-rounded-circle-back-show button-custom" do %>
             <i class="fa-solid fa-arrow-left" style="color: #5465ff;"></i>
           <% end %>
         </div>

--- a/app/views/belongings/show.html.erb
+++ b/app/views/belongings/show.html.erb
@@ -11,15 +11,13 @@
             <div class="carousel-item">
               <%= cl_image_tag photo.key, height: 200, width: 425, crop: :fill, class: "image-big d-block" %>
             </div>
-          <% end%>
+          <% end %>
         <% end %>
-          <div class="d-flex">
-            <%= link_to flat_path(@belonging.flat) do %>
-              <button class="btn-rounded-circle-back back-arrow" type="button">
-                <i class="fa-solid fa-arrow-left arrow" style="color: #5465ff;"></i>
-              </button>
-            <% end %>
-          </div>
+        <div class="d-flex">
+          <%= button_to flat_path(@belonging.flat), class: "btn-rounded-circle-back-show button-custom" do %>
+            <i class="fa-solid fa-arrow-left" style="color: #5465ff;"></i>
+          <% end %>
+        </div>
       </div>
     </div>
     <a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-slide="prev">
@@ -31,10 +29,10 @@
       <span class="sr-only">Next</span>
     </a>
   </div>
-      <div class="headline-description-belonging">
-          <h3 class="headline-belonging"><%= @belonging.name.capitalize %></h3>
-          <%= @belonging.category.name.capitalize %>
-      </div>
+  <div class="headline-description-belonging">
+    <h3 class="headline-belonging"><%= @belonging.name.capitalize %></h3>
+    <%= @belonging.category.name.capitalize %>
+  </div>
   <div class="status-icon-overlap">
     <% if @belonging.good? %>
       <div class="col-3 background-blue-belonging">
@@ -60,12 +58,12 @@
   <h3 class="belonging-headline">Attachments</h3>
   <% if @belonging.files.count.zero? %>
     <p>No attachments uploaded ❌</p>
-    <% else %>
-      <% @belonging.files.each do |file|%>
-        <div class="attachment-belonging mb-2" data-bs-toggle="modal" data-bs-target="#pdfmodal" data-bs-whatever="<%= Cloudinary::Api.resource("#{Rails.env}/#{file.key}")['secure_url'][..-4] + 'jpg' %>">
-          <i class="fa-solid fa-file" style="color: #888888;"></i>
-          <%= file.blob.filename %>
-        </div>
+  <% else %>
+    <% @belonging.files.each do |file| %>
+      <div class="attachment-belonging mb-2" data-bs-toggle="modal" data-bs-target="#pdfmodal" data-bs-whatever="<%= Cloudinary::Api.resource("#{Rails.env}/#{file.key}")['secure_url'][..-4] + 'jpg' %>">
+        <i class="fa-solid fa-file" style="color: #888888;"></i>
+        <%= file.blob.filename %>
+      </div>
     <% end %>
   <% end %>
 
@@ -86,22 +84,22 @@
   </div>
 
   <script>
-    const pdfModal = document.getElementById('pdfmodal')
-    pdfModal.addEventListener('show.bs.modal', function (event) {
-      // Button that triggered the modal
-      const button = event.relatedTarget
-      // Extract info from data-bs-* attributes
-      const url = button.getAttribute('data-bs-whatever')
-      // If necessary, you could initiate an AJAX request here
-      // and then do the updating in a callback.
-      //
-      // Update the modal's content.
-      const object = document.getElementById("pdf-iframe")
-      const link = object.querySelector('a')
+      const pdfModal = document.getElementById('pdfmodal')
+      pdfModal.addEventListener('show.bs.modal', function (event) {
+          // Button that triggered the modal
+          const button = event.relatedTarget
+          // Extract info from data-bs-* attributes
+          const url = button.getAttribute('data-bs-whatever')
+          // If necessary, you could initiate an AJAX request here
+          // and then do the updating in a callback.
+          //
+          // Update the modal's content.
+          const object = document.getElementById("pdf-iframe")
+          const link = object.querySelector('a')
 
-      object.setAttribute("data", url)
-      link.href = url
-    })
+          object.setAttribute("data", url)
+          link.href = url
+      })
   </script>
 
 
@@ -127,7 +125,8 @@
             <%= todo.user.first_name %>
             <%= todo.user.last_name.first %>. reported:
             <%= todo.description.capitalize.first(35) %>
-            <% if todo.description.length > 35 %>...<% end %>
+            <% if todo.description.length > 35 %>...
+            <% end %>
           </h5>
           <p class="reported-text-history">Reported on: <%= todo.created_at.strftime('%m/%d/%Y') %></p>
           <p class="reported-text-history">Back to fine: <%= todo.updated_at.strftime('%m/%d/%Y') %></p>
@@ -138,11 +137,11 @@
 
   <div class="mt-5">
     <%= link_to "» Delete belonging",
-      flat_belonging_path(@belonging.flat, @belonging),
-      data: {
-        turbo_method: :delete,
-        turbo_confirm: "Are you sure?"
-      } %>
+                flat_belonging_path(@belonging.flat, @belonging),
+                data: {
+                  turbo_method: :delete,
+                  turbo_confirm: "Are you sure?"
+                } %>
   </div>
 
 </div>

--- a/app/views/flats/_landlord_all_items.html.erb
+++ b/app/views/flats/_landlord_all_items.html.erb
@@ -1,74 +1,80 @@
 <% @belongings.each do |belonging| %>
-        <div class="d-flex card-belonging justify-content-between mb-3">
-          <% if belonging.good? %>
-              <div class="col-4 background-blue">
-                <%= cl_image_tag belonging.photos.first.key, quality: 10, class: "flex-shrink-1 image-flat-good" %>
-                <button class="modal-button" data-bs-toggle="modal" data-bs-target="#exampleModal">
-                  <i class="fa-solid fa-check icon-good " style="color: #fdfdfd;"></i>
-                </button>
-              </div>
+  <div class="d-flex card-belonging justify-content-between mb-3">
+    <% if belonging.good? %>
+      <div class="col-4 background-blue">
+        <%= cl_image_tag belonging.photos.first.key, quality: 10, class: "flex-shrink-1 image-flat-good" %>
+        <button class="modal-button" data-bs-toggle="modal" data-bs-target="#exampleModal">
+          <i class="fa-solid fa-check icon-good " style="color: #fdfdfd;"></i>
+        </button>
+      </div>
 
-            <!-- Modal -->
-              <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-                <div class="modal-dialog modal-dialog-centered">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <h5 class="text-center flex-grow-1" id="exampleModalLabel">Report Issue 🛠</h5>
-                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <%= simple_form_for [@flat, belonging, @todo] do |f|%>
-                      <div class="modal-body">
-                        <div>
-                          <div class="d-flex justify-content-center mb-3">
-                            <label>
-                              <input type="radio" name="todo[belonging_status]" value="damaged" checked>
-                              <div class="col-4 background-beige-icon">
-                                <%= cl_image_tag belonging.photos.first.key, class: "flex-shrink-1 image-flat-good-icon" %>
-                                <i class="fa-solid fa-hammer icon-repair" style="color: #fdfdfd;"></i>
-                              </div>
-                            </label>
-                            <label>
-                              <input type="radio" name="todo[belonging_status]" value="needs_replacement">
-                              <div class="col-4 background-red-icon">
-                                <%= cl_image_tag belonging.photos.first.key, class: "flex-shrink-1 image-flat-good-icon" %>
-                                <i class="fa-solid fa-exclamation icon-replacement" style="color: #fdfdfd;"></i>
-                              </div>
-                            </label>
-                          </div>
-                        </div>
-                        <div>
-                            <%= f.input :description %>
-                            <%= f.input :photos, as: :file, input_html: { class: "mb-2 custom-input", multiple: true } %>
-                            <%= f.input :files, as: :file, input_html: { class: "mb-2 custom-input", multiple: true } %>
-                        </div>
+      <!-- Modal -->
+      <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="text-center flex-grow-1" id="exampleModalLabel">Report Issue 🛠</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <%= simple_form_for [@flat, belonging, @todo] do |f| %>
+              <div class="modal-body">
+                <div>
+                  <div class="d-flex justify-content-center mb-3">
+                    <label>
+                      <input type="radio" name="todo[belonging_status]" value="damaged" checked>
+                      <div class="col-4 background-beige-icon">
+                        <%= cl_image_tag belonging.photos.first.key, class: "flex-shrink-1 image-flat-good-icon" %>
+                        <i class="fa-solid fa-hammer icon-repair" style="color: #fdfdfd;"></i>
                       </div>
-                      <div class="modal-footer justify-content-center">
-                          <%= f.button :submit, "Save Report", class:"btn-text" %>
+                    </label>
+                    <label>
+                      <input type="radio" name="todo[belonging_status]" value="needs_replacement">
+                      <div class="col-4 background-red-icon">
+                        <%= cl_image_tag belonging.photos.first.key, class: "flex-shrink-1 image-flat-good-icon" %>
+                        <i class="fa-solid fa-exclamation icon-replacement" style="color: #fdfdfd;"></i>
                       </div>
-                    <% end %>
+                    </label>
                   </div>
                 </div>
+                <div>
+                  <%= f.input :description %>
+                  <%= f.input :photos, as: :file, input_html: { class: "mb-2 custom-input", multiple: true } %>
+                  <%= f.input :files, as: :file, input_html: { class: "mb-2 custom-input", multiple: true } %>
+                </div>
               </div>
-          <% elsif belonging.damaged? %>
+              <div class="modal-footer justify-content-center">
+                <%= f.button :submit, "Save Report",
+
+                             class
+                               :"btn-text" %>
+                  </div>
+                <% end %>
+                </div>
+                </div>
+                </div>
+                <% elsif belonging.damaged? %>
                 <div class="col-4 background-beige">
                   <%= cl_image_tag belonging.photos.first.key, quality: 10, class: "flex-shrink-1 image-flat-good" %>
                   <i class="fa-solid fa-hammer icon-repair" style="color: #fdfdfd;"></i>
                 </div>
-          <% else %>
-                <div class="col-4 background-red">
-                  <%= cl_image_tag belonging.photos.first.key, quality: 10, class: "flex-shrink-1 image-flat-good" %>
-                  <i class="fa-solid fa-exclamation icon-replacement" style="color: #fdfdfd;"></i>
-                </div>
-          <% end %>
-              <h3 class="my-auto flex-grow-1 text-belonging"> <%= belonging.name %></h3>
-              <button class="my-auto me-3 btn-square" type="button" data-bs-toggle="collapse" data-bs-target="#<%= belonging.id %>" aria-expanded="false" aria-controls="collapseExample">
-                <i class="fa-solid fa-caret-down" style="color: #fdfdfd;"></i>
-              </button>
-        </div>
-        <div class="collapse mb-3 belonging-preview" id="<%= belonging.id %>">
-            <div class="card card-body no-border">
-              <p><%= belonging.description %></p>
-              <%= link_to "See more", flat_belonging_path(@flat, belonging), class:"btn-text" %>
+            <% else %>
+              <div class="col-4 background-red">
+                <%= cl_image_tag belonging.photos.first.key, quality: 10, class: "flex-shrink-1 image-flat-good" %>
+                <i class="fa-solid fa-exclamation icon-replacement" style="color: #fdfdfd;"></i>
+              </div>
+            <% end %>
+            <h3 class="my-auto flex-grow-1 text-belonging"> <%= belonging.name %></h3>
+            <button class="my-auto me-3 btn-square btn-blue button-custom" type="button" data-bs-toggle="collapse" data-bs-target="#<%= belonging.id %>" aria-expanded="false" aria-controls="collapseExample">
+              <i class="fa-solid fa-caret-down" style="color: #fdfdfd;"></i>
+            </button>
             </div>
-        </div>
-      <% end %>
+            <div class="collapse mb-3 belonging-preview" id="<%= belonging.id %>">
+              <div class="card card-body no-border">
+                <p><%= belonging.description %></p>
+                <%= link_to "See more", flat_belonging_path(@flat, belonging),
+
+                            class
+                              :"btn-text" %>
+                  </div>
+                  </div>
+                <% end %>

--- a/app/views/flats/_landlord_needs_attention.html.erb
+++ b/app/views/flats/_landlord_needs_attention.html.erb
@@ -4,40 +4,45 @@
   <% @belongings_attention.each do |belonging| %>
     <div>
       <div class="d-flex card-belonging justify-content-between mb-3">
-          <% if belonging.damaged? %>
-              <div class="col-4 background-beige">
-                <%= cl_image_tag belonging.photos.first.key, class: "flex-shrink-1 image-flat-good" %>
-                <i class="fa-solid fa-hammer icon-repair" style="color: #fdfdfd;"></i>
-              </div>
-          <% elsif belonging.needs_replacement? %>
-              <div class="col-4 background-red">
-                <%= cl_image_tag belonging.photos.first.key, class: "flex-shrink-1 image-flat-good" %>
-                <i class="fa-solid fa-exclamation icon-replacement" style="color: #fdfdfd;"></i>
-              </div>
+        <% if belonging.damaged? %>
+          <div class="col-4 background-beige">
+            <%= cl_image_tag belonging.photos.first.key, class: "flex-shrink-1 image-flat-good" %>
+            <i class="fa-solid fa-hammer icon-repair" style="color: #fdfdfd;"></i>
+          </div>
+        <% elsif belonging.needs_replacement? %>
+          <div class="col-4 background-red">
+            <%= cl_image_tag belonging.photos.first.key, class: "flex-shrink-1 image-flat-good" %>
+            <i class="fa-solid fa-exclamation icon-replacement" style="color: #fdfdfd;"></i>
+          </div>
+        <% end %>
+        <h3 class="my-auto flex-grow-1 text-belonging">
+          <%= belonging.name.first(12) %>
+          <% if belonging.name.length > 12 %>...
           <% end %>
-            <h3 class="my-auto flex-grow-1 text-belonging">
-              <%= belonging.name.first(12) %>
-              <% if belonging.name.length > 12 %>...<% end %>
-            </h3>
-            <div class="checked-belonging">
-              <%= link_to "/flats/#{@flat.id}/belongings/#{belonging.id}/todos/#{belonging.todos.first.id}", data: { 'turbo-method': :patch, action: "click->check-todo#check" } do %>
-                <button class="my-auto me-3 btn-square">
-                    <i class="fa-solid fa-check" style="color: #fdfdfd;"></i>
-                </button>
-              <% end %>
-            </div>
-            <button class="my-auto me-3 btn-square" type="button" data-bs-toggle="collapse" data-bs-target="#<%= belonging.todos.first.id %>" aria-expanded="false" aria-controls="collapseExample">
-              <i class="fa-solid fa-caret-down" style="color: #fdfdfd;"></i>
+        </h3>
+        <div class="checked-belonging">
+          <%= link_to "/flats/#{@flat.id}/belongings/#{belonging.id}/todos/#{belonging.todos.first.id}", data: { 'turbo-method': :patch, action: "click->check-todo#check" } do %>
+            <button class="me-3 btn-square btn-blue button-custom">
+              <i class="fa-solid fa-check" color="#fdfdfd"></i>
             </button>
+          <% end %>
+        </div>
+        <button class="my-auto me-3 btn-square btn-blue button-custom" type="button" data-bs-toggle="collapse" data-bs-target="#<%= belonging.todos.first.id %>" aria-expanded="false" aria-controls="collapseExample">
+          <i class="fa-solid fa-caret-down" style="color: #fdfdfd;"></i>
+        </button>
       </div>
       <div class="collapse mb-3 belonging-preview" id="<%= belonging.todos.first.id %>">
-          <div class="card card-body no-border">
-            <h3><% if belonging.name.length > 12 %> <%= belonging.name%> <% end %> </h3>
-            <h3>Active Todo:</h3>
-            <p><b>Uploaded by:</b> <%= belonging.todos.select(&:active?).first.user.first_name %> <%= belonging.todos.select(&:active?).first.user.last_name.first %>. on <%= belonging.todos.select(&:active?).first.created_at.strftime('%m/%d/%Y') %></p>
-            <p><%= belonging.todos.select(&:active?).first.description %></p>
-            <%= link_to "See more", flat_belonging_path(@flat, belonging), class:"btn-text" %>
-          </div>
+        <div class="card card-body no-border">
+          <h3>
+            <% if belonging.name.length > 12 %> <%= belonging.name %>
+            <% end %> </h3>
+          <h3>Active Todo:</h3>
+          <p><b>Uploaded
+            by:</b> <%= belonging.todos.select(&:active?).first.user.first_name %> <%= belonging.todos.select(&:active?).first.user.last_name.first %>
+            . on <%= belonging.todos.select(&:active?).first.created_at.strftime('%m/%d/%Y') %></p>
+          <p><%= belonging.todos.select(&:active?).first.description %></p>
+          <%= link_to "See more", flat_belonging_path(@flat, belonging), class: "btn-text" %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/flats/show.html.erb
+++ b/app/views/flats/show.html.erb
@@ -1,21 +1,23 @@
 <% if current_user.landlord? %>
-  <div class="d-flex" style="background-image: linear-gradient(rgba(84,101,255,0.7), rgba(84,101,255,0.7)), url('<%= cl_image_path @flat.photos.first.key, height: 300, crop: :fill %>')">
-    <div class="spacing-header">
-      <%= link_to flats_path do %>
-        <button class="btn-rounded-circle-back-show" type="button">
-          <i class="fa-solid fa-arrow-left back-arrow1" style="color: #5465ff;"></i>
-        </button>
+  <div class="d-flex flex-column" style="background-image: linear-gradient(rgba(84,101,255,0.7), rgba(84,101,255,0.7)), url('<%= cl_image_path @flat.photos.first.key, height: 300, crop: :fill %>')">
+    <div class="navigation-container">
+      <%= link_to flats_path, class: "btn-rounded-circle-back-show button-custom" do %>
+        <i class="fa-solid fa-arrow-left" style="color: #5465ff;"></i>
       <% end %>
-      <h1><%= @flat.name %></h1>
-      <h6><%= @flat.address %></h6>
     </div>
-    <div class="justify-content-center edit-share">
-      <button class="btn-square-white" type="button">
-        <i class="fa-solid fa-pen"></i>
-      </button>
-      <button class="btn-square-white" type="button" data-bs-toggle="modal" data-bs-target="#userModal">
-        <i class="fa-solid fa-share-nodes"></i>
-      </button>
+    <div class="d-flex flex-row justify-content-around">
+      <div class="spacing-header">
+        <h1><%= @flat.name %></h1>
+        <h6><%= @flat.address %></h6>
+      </div>
+      <div class="justify-content-center">
+        <button class="btn-square btn-white button-custom" type="button">
+          <i class="fa-solid fa-pen"></i>
+        </button>
+        <button class="btn-square btn-white button-custom" type="button" data-bs-toggle="modal" data-bs-target="#userModal">
+          <i class="fa-solid fa-share-nodes"></i>
+        </button>
+      </div>
     </div>
   </div>
   <div class="page-container mt-3">
@@ -89,7 +91,6 @@
       </div>
 
 
-
       <div class="belonging-container d-none" data-all-items-flat-number-value="<%= @flat.id %>" data-all-items-target="container">
       </div>
     </div>
@@ -100,7 +101,7 @@
 <%# --- Tenants Page --- %>
 <% elsif current_user.tenant? %>
   <div class="d-flex" style="background-image: linear-gradient(rgba(84,101,255,0.7), rgba(84,101,255,0.7)), url('<%= cl_image_path @flat.photos.first.key, height: 300, crop: :fill %>')">
-    <div class ="spacing-header">
+    <div class="spacing-header">
       <%= link_to flats_path do %>
         <button class="btn-rounded-circle-back back-arrow" type="button">
           <i class="fa-solid fa-arrow-left" style="color: #5465ff;"></i>
@@ -134,14 +135,15 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h1 class="modal-title fs-5" id="addBelongingLabel">New Belonging <i class="fa-solid fa-tv" style="color: #5465ff;"></i></h1>
+        <h1 class="modal-title fs-5" id="addBelongingLabel">New Belonging
+          <i class="fa-solid fa-tv" style="color: #5465ff;"></i></h1>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <%= simple_form_for [@flat, @belonging], data: {controller: "dropdown"} do |f| %>
+        <%= simple_form_for [@flat, @belonging], data: { controller: "dropdown" } do |f| %>
           <%= f.input :name, placeholder: 'Belonging name', input_html: { class: "mb-2 custom-input" } %>
           <hr>
-          <%= f.label :category, :class => "mb-2"  %>
+          <%= f.label :category, :class => "mb-2" %>
           <div class="custom--form--dropdown--container mb-2">
             <input name="selected_room" type="hidden" data-dropdown-target="inputFieldHidden" placeholder="Choose category">
             <div class="custom--form--field ph--12" data-dropdown-target="selectedRoom">
@@ -155,16 +157,16 @@
               </div>
             </div>
           </div>
-          <%= f.input :description, placeholder: 'Describe your belonging', input_html: { class: "mb-2 custom-input" }%>
+          <%= f.input :description, placeholder: 'Describe your belonging', input_html: { class: "mb-2 custom-input" } %>
           <hr>
-          <%= f.input :photos, as: :file, placeholder: 'No photos', input_html: { class: "mb-2 custom-input", multiple: true} %>
+          <%= f.input :photos, as: :file, placeholder: 'No photos', input_html: { class: "mb-2 custom-input", multiple: true } %>
           <hr>
           <%= f.input :files, placeholder: 'No photos', as: :file, input_html: { class: "mb-2 custom-input", multiple: true } %>
+          </div>
+          <div class="modal-footer">
+            <%= f.submit "Save", class: "btn-text" %>
+          </div>
+        <% end %>
         </div>
-        <div class="modal-footer">
-          <%= f.submit "Save", class: "btn-text" %>
-        </div>
-      <% end %>
-    </div>
   </div>
 </div>

--- a/app/views/pages/profile.html.erb
+++ b/app/views/pages/profile.html.erb
@@ -1,35 +1,33 @@
 <div class="background-curve w-150">
   <% if current_user %>
     <% if current_user.photo.attached? %>
-        <%= cl_image_tag current_user.photo.key, class: " profile-pic rounded-circle mr-3", :gravity=>"face", :height=>150, :width=>150, :crop=>"thumb" %>
-      <% else %>
-        <%= image_tag "houselist_default_profile_pic.jpg", alt: "default image", width: 40, height: 40, class: " profile-pic rounded-circle mr-3" %>
-      <% end %>
+      <%= cl_image_tag current_user.photo.key, class: " profile-pic rounded-circle mr-3", :gravity => "face", :height => 150, :width => 150, :crop => "thumb" %>
+    <% else %>
+      <%= image_tag "houselist_default_profile_pic.jpg", alt: "default image", width: 40, height: 40, class: " profile-pic rounded-circle mr-3" %>
+    <% end %>
   <% end %>
   <div>
   </div>
-    <div class="position-button">
-      <%= link_to edit_user_registration_path(@user) do %>
-        <button class="btn-edit">
-          <i class="fa-solid fa-pen " style=" padding-left: 7px;"></i>
-        </button>
-      <% end %>
-      </div>
-        </div>
-          <div class="page-container page-margin-top">
-            <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
-              <h2><i class="fa-regular fa-envelope align-items-center me-3 icon-profile"></i> <%=current_user.email%></p>
-            </div>
-            <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
-              <h2><i class="fa-regular fa-address-card me-3 icon-profile"></i> <%=current_user.first_name%></p>
-            </div>
-            <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
-              <h2><i class="fa-regular fa-address-card me-3 icon-profile"></i> <%=current_user.last_name%></p>
-            </div>
-            <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
-              <h2><i class="fa-regular fa-user me-3 icon-profile"></i> <%=current_user.role%></p>
-            </div>
-            <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
-              <%= link_to 'logout', destroy_user_session_path, data: {turbo_method: :delete} %>
-            </div>
-        </div>
+  <div class="position-button">
+    <%= link_to edit_user_registration_path(@user), class: "btn-edit button-custom" do %>
+      <i class="fa-solid fa-pen " style=" padding-left: 7px;"></i>
+    <% end %>
+  </div>
+</div>
+<div class="page-container page-margin-top">
+  <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
+    <h2><i class="fa-regular fa-envelope align-items-center me-3 icon-profile"></i> <%= current_user.email %></h2>
+  </div>
+  <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
+    <h2><i class="fa-regular fa-address-card me-3 icon-profile"></i> <%= current_user.first_name %></h2>
+  </div>
+  <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
+    <h2><i class="fa-regular fa-address-card me-3 icon-profile"></i> <%= current_user.last_name %></h2>
+  </div>
+  <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
+    <h2><i class="fa-regular fa-user me-3 icon-profile"></i> <%= current_user.role %></h2>
+  </div>
+  <div class="my-3 d-flex align-items-center profile-content m-3 ms-5">
+    <%= link_to 'logout', destroy_user_session_path, data: { turbo_method: :delete } %>
+  </div>
+</div>

--- a/app/views/shared/_todo_card.html.erb
+++ b/app/views/shared/_todo_card.html.erb
@@ -5,8 +5,9 @@
     </div>
 
     <div class="d-flex justify-content-between align-items-center">
-      <p class="my-auto flex-grow-1 text-todo"><%= @active_todo.user.first_name %> <%= @active_todo.user.last_name.first %>. reported: <%= @active_todo.description %></p>
-      <button class="my-auto me-3 btn-square" type="button" data-bs-toggle="collapse" data-bs-target="#<%= @active_todo.id %>" aria-expanded="false" aria-controls="collapseExample">
+      <p class="my-auto flex-grow-1 text-todo"><%= @active_todo.user.first_name %> <%= @active_todo.user.last_name.first %>
+        . reported: <%= @active_todo.description %></p>
+      <button class="my-auto me-3 btn-square btn-blue button-custom" type="button" data-bs-toggle="collapse" data-bs-target="#<%= @active_todo.id %>" aria-expanded="false" aria-controls="collapseExample">
         <i class="fa-solid fa-caret-down" style="color: #fdfdfd;"></i>
       </button>
     </div>
@@ -17,7 +18,7 @@
       <% unless @active_todo.files.first.nil? %>
         <p>
           Attached files:
-          <% @active_todo.files.each do |file|%>
+          <% @active_todo.files.each do |file| %>
           <div class="attachment-belonging mb-2" data-bs-toggle="modal" data-bs-target="#pdfmodal" data-bs-whatever="<%= Cloudinary::Api.resource("#{Rails.env}/#{file.key}")['secure_url'][..-4] + 'jpg' %>">
             <i class="fa-solid fa-file" style="color: #888888;"></i>
             <%= file.blob.filename %>
@@ -28,7 +29,7 @@
       <% unless @active_todo.photos.first.nil? %>
         <p>
           Attached photos:
-          <% @active_todo.photos.each do |photo|%>
+          <% @active_todo.photos.each do |photo| %>
           <div class="attachment-belonging mb-2" data-bs-toggle="modal" data-bs-target="#pdfmodal" data-bs-whatever="<%= Cloudinary::Api.resource("#{Rails.env}/#{photo.key}")['secure_url'][..-4] + 'jpg' %>">
             <i class="fa-solid fa-image" style="color: #888888;"></i>
             <%= photo.blob.filename %>


### PR DESCRIPTION
- 🔧 chore(button.scss): refactor button styles 🎨 style(button.scss): improve button styles and add new classes The button styles have been refactored to improve readability and maintainability. The changes include: - Renaming the `.btn-square` class to `.btn-rounded-circle-back-show` to better reflect its purpose. - Adding a new `.button-custom` class with flexbox properties for centering and aligning the button content. - Adding new classes `.btn-white`, `.btn-blue`, and `.navigation-container` for specific styling purposes. These changes enhance the overall button styles and provide more flexibility for customization.
- 🎨 style(button.scss): add new CSS class .navigation-container-relative 🔧 fix(show.html.erb): adjust image width to 400px instead of 425px 🔧 fix(show.html.erb): change button_to to link_to for back button The new CSS class .navigation-container-relative is added to provide a relative positioning context for its child elements. The image width in the show.html.erb file is adjusted to 400px instead of 425px for better visual consistency. The button_to method is replaced with link_to method for the back button to ensure proper functionality.
